### PR TITLE
fix: update scan-alauda workflow to scan alauda-yq binary

### DIFF
--- a/.github/workflows/scan-alauda.yaml
+++ b/.github/workflows/scan-alauda.yaml
@@ -30,5 +30,5 @@ jobs:
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'rootfs'
-          scan-ref: 'dist/cosign_linux_amd64_v1/alauda-cosign'
+          scan-ref: 'dist/yq_linux_amd64_v1/alauda-yq'
           exit-code: 1


### PR DESCRIPTION
Updates the Trivy security scan reference from alauda-cosign to alauda-yq to match the correct binary for this repository.