### PR TITLE
chore(ci): update go version detection and devtools install

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -907,15 +908,8 @@ func (f *mockBoolFlag) Type() string {
 
 // Helper function to compare string slices
 func stringsEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	// Use the standard library comparator to avoid manual index handling.
+	return slices.Equal(a, b)
 }
 
 func TestSetupColors(t *testing.T) {

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -ex
+
+# Keep tooling installation deterministic and aligned with the active Go toolchain.
+# This avoids prebuilt golangci-lint binaries being built by an older Go version.
+GOLANGCI_LINT_VERSION=v2.11.2
+GOSEC_VERSION=v2.22.5
+
 go mod download golang.org/x/tools@latest
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
-curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.22.5
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s ${GOSEC_VERSION}


### PR DESCRIPTION
- Use go-version-file in CI to align Go version with go.mod
- Extract GOLANGCI_LINT_VERSION and GOSEC_VERSION as variables
- Replace curl-based golangci-lint install with go install for reproducibility
- Bump golangci-lint from v2.4.0 to v2.11.2