### PR TITLE
[debug] Add sync-to-nexus workflow + Tekton pipeline trigger

### DIFF
--- a/.github/workflows/sync-to-nexus.yml
+++ b/.github/workflows/sync-to-nexus.yml
@@ -10,11 +10,25 @@ on:
   push:
     tags:
       - 'v*-alauda-*'
+  # Debug-phase: lets us iterate on this workflow file inside a PR
+  # against master without first merging it. GitHub picks up the
+  # workflow content from the PR head branch for `pull_request` events,
+  # which is what makes "test the workflow before it lands on master"
+  # possible. Required because `workflow_dispatch` only registers
+  # workflows that already exist on the default branch — so until this
+  # file lands on master, PR is the only path to a real GA run. The
+  # `paths` filter scopes triggers to edits of this file specifically,
+  # so unrelated source-code commits in the PR do not re-spam runs.
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/sync-to-nexus.yml'
   # Debug-phase: lets the maintainer re-run the Pipeline against an
   # ALREADY-PUBLISHED tag from the GitHub Actions UI (Run workflow
   # button) without pushing a new tag. Pick the tag from the input
   # field; the default points at a known-good tag with full release
-  # assets so smoke runs are zero-config.
+  # assets so smoke runs are zero-config. Note: `workflow_dispatch`
+  # only becomes available once this file is on the default branch.
   workflow_dispatch:
     inputs:
       tag:
@@ -42,13 +56,17 @@ jobs:
           # github.run_id is globally unique; run_attempt disambiguates re-runs.
           PR_NAME: sync-${{ github.run_id }}-${{ github.run_attempt }}
           REPO: ${{ github.repository }}
-          # On `push` (tag) events, github.ref_name is the tag itself.
-          # On `workflow_dispatch`, github.ref_name is the branch the
-          # workflow file lives on (useless), so we read inputs.tag
-          # instead. The fallback chain `inputs.tag || ref_name` lets
-          # both triggers share the rest of the script unchanged.
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
-          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag || github.ref_name }}
+          # Tag selection priority:
+          #   1. `workflow_dispatch.inputs.tag` (UI Run-workflow button).
+          #   2. `pull_request` event → `github.ref_name` is the PR's
+          #      head branch name (useless as a release tag), so fall
+          #      back to a known-good debug tag with full release assets.
+          #   3. `push:tags` → `github.ref_name` is the tag itself.
+          # GitHub Actions has no real ternary; the `&&`/`||`
+          # short-circuit chain emulates one — `(cond && X) || Y`
+          # yields X when cond is truthy and Y otherwise.
+          TAG: ${{ github.event.inputs.tag || (github.event_name == 'pull_request' && 'v4.47.2-alauda-19') || github.ref_name }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag || (github.event_name == 'pull_request' && 'v4.47.2-alauda-19') || github.ref_name }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/sync-to-nexus.yml
+++ b/.github/workflows/sync-to-nexus.yml
@@ -1,0 +1,112 @@
+name: Sync Release To Nexus
+
+# Triggers a Hub-resolved Tekton PipelineRun on the in-cluster ARC runner
+# whenever an alauda-suffixed tag is pushed. The pipeline (defined in
+# ops/edge-devops-task, exposed via Hub catalog `extras`) waits for the
+# corresponding GitHub Release to be ready, then mirrors its assets to
+# the internal Nexus under both a versioned path and a `latest/` channel.
+
+on:
+  push:
+    tags:
+      - 'v*-alauda-*'
+  # Debug-phase: lets the maintainer re-run the Pipeline against an
+  # ALREADY-PUBLISHED tag from the GitHub Actions UI (Run workflow
+  # button) without pushing a new tag. Pick the tag from the input
+  # field; the default points at a known-good tag with full release
+  # assets so smoke runs are zero-config.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to mirror (e.g. v4.47.2-alauda-19)'
+        required: true
+        default: 'v4.47.2-alauda-19'
+
+jobs:
+  trigger-sync:
+    # Base ARC runner image already bundles tkn / kubectl / curl / jq / yq;
+    # no `container:` override needed.
+    runs-on: alauda-devops-runner
+    steps:
+      - name: create PipelineRun (Hub-resolved) and follow logs
+        env:
+          TEKTON_NS: devops
+          # Debug mode: the Pipeline is `kubectl apply`-ed directly into
+          # ${TEKTON_NS} by the maintainer for end-to-end testing before
+          # the catalog PR lands. Once merged into Tekton Hub catalog
+          # `extras`, switch the `pipelineRef` block below back to the
+          # hub resolver form (catalog=extras / kind=pipeline /
+          # name=sync-github-release-to-nexus / version=0.1).
+          PIPELINE_NAME: sync-github-release-to-nexus
+          # Deterministic PipelineRun name avoids racy label lookup.
+          # github.run_id is globally unique; run_attempt disambiguates re-runs.
+          PR_NAME: sync-${{ github.run_id }}-${{ github.run_attempt }}
+          REPO: ${{ github.repository }}
+          # On `push` (tag) events, github.ref_name is the tag itself.
+          # On `workflow_dispatch`, github.ref_name is the branch the
+          # workflow file lives on (useless), so we read inputs.tag
+          # instead. The fallback chain `inputs.tag || ref_name` lets
+          # both triggers share the rest of the script unchanged.
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # Source-repo label uses dots instead of slashes to satisfy
+          # Kubernetes label value charset (no '/').
+          SOURCE_REPO_LABEL="${REPO//\//.}"
+
+          # Create PipelineRun with metadata.name (not generateName) so the
+          # PR name is known up front for `tkn pr logs -f` below.
+          # github-token workspace intentionally omitted: forks are public,
+          # pipeline declares it `optional: true` and falls back to anonymous.
+          cat <<EOF | kubectl create -f -
+          apiVersion: tekton.dev/v1
+          kind: PipelineRun
+          metadata:
+            name: ${PR_NAME}
+            namespace: ${TEKTON_NS}
+            labels:
+              alauda.io/source-repo: ${SOURCE_REPO_LABEL}
+              alauda.io/source-tag: ${TAG}
+              alauda.io/triggered-by: github-actions
+          spec:
+            # Debug-phase: reference the in-namespace Pipeline by name.
+            # Replace this block with the `resolver: hub` form once the
+            # Pipeline is merged into the catalog (see PIPELINE_NAME env
+            # comment above).
+            pipelineRef:
+              name: ${PIPELINE_NAME}
+            params:
+              - { name: repo,        value: ${REPO} }
+              - { name: tag,         value: ${TAG} }
+              - { name: release-url, value: ${RELEASE_URL} }
+            workspaces:
+              - name: nexus-auth
+                secret:
+                  secretName: build-nexus.kauto
+              # Shared scratch PVC across the 5 run-script tasks. emptyDir
+              # would be per-pod and cannot propagate downloaded assets +
+              # intermediate metadata across TaskRuns; volumeClaimTemplate
+              # makes Tekton create a PipelineRun-owned PVC reaped with
+              # the run. RWO is sufficient — the DAG is strictly linear.
+              - name: source
+                volumeClaimTemplate:
+                  spec:
+                    storageClassName: topolvm
+                    accessModes:
+                      - ReadWriteOnce
+                    resources:
+                      requests:
+                        storage: 1Gi
+          EOF
+
+          # Stream logs until the PipelineRun completes; then surface the
+          # PipelineRun's Succeeded condition as the step exit code so the
+          # GitHub Actions UI reflects the real pipeline outcome.
+          tkn -n "${TEKTON_NS}" pr logs -f "${PR_NAME}"
+
+          STATUS=$(kubectl -n "${TEKTON_NS}" get pipelinerun "${PR_NAME}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}')
+          echo "PipelineRun ${PR_NAME} final Succeeded status: ${STATUS}"
+          [ "${STATUS}" = "True" ]


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-to-nexus.yml` that, on every \`v*-alauda-*\` tag push, creates a Hub-resolved Tekton PipelineRun on the in-cluster ARC runner to mirror the GitHub Release assets to internal Nexus.
- Workflow lives in this PR (not yet on master) so it triggers via \`pull_request\` against this file path; \`workflow_dispatch\` will become available once merged.
- The Tekton pipeline itself ships in https://github.com/AlaudaDevops/edge-devops-task (branch \`feat/sync-github-release-to-nexus\`, soon to land in catalog \`extras\`).

## How this is being tested

Path A (in-namespace pipeline + sample PipelineRun): ✅ green end-to-end on the integration cluster — assets land at \`https://build-nexus.alauda.cn/repository/alauda/devops/github-releases/AlaudaDevops/yq/v4.47.2-alauda-19/\` and \`.../latest/\`, \`_meta.json\` written, Tekton overview-markdown shows clickable Nexus UI deep-links.

Path B (this PR): triggering via \`pull_request\` to validate the GitHub Actions trigger surface end-to-end before the Tekton pipeline merges into the catalog and we flip the \`pipelineRef\` to \`resolver: hub\`.

## Test plan

- [ ] First PR commit fires \`Sync Release To Nexus\` workflow run
- [ ] Workflow creates PipelineRun \`sync-<run_id>-<run_attempt>\` in the \`devops\` ns
- [ ] PipelineRun reaches \`Succeeded=True\` (5 tasks: wait-for-release → download-and-verify → upload-versioned → decide-latest → upload-latest)
- [ ] Pipeline results \`versioned-base-url\`, \`latest-base-url\`, \`latest-updated\` populated correctly
- [ ] Re-running the workflow against the same tag fails fast at \`upload-versioned\` (Nexus write-once contract → US-4)

## Out of scope for this PR

- Replicating to other forks (trivy / cosign / chains) — comes after this lands.
- Switching \`pipelineRef\` from in-namespace name to \`resolver: hub\` — gated on the catalog PR for the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)