### PR TITLE
chore(go): bump Go toolchain version

### DIFF
--- a/.github/workflows/alauda-auto-tag.yaml
+++ b/.github/workflows/alauda-auto-tag.yaml
@@ -1,0 +1,87 @@
+name: Auto Tag for Alauda
+
+on:
+  push:
+    branches:
+      - 'alauda-v*'
+
+permissions:
+  contents: write  # create tags and releases
+  packages: write  # upload packages
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all tags
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version and tag prefix
+        id: extract
+        run: |
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          echo "Branch: $BRANCH_NAME"
+
+          PREFIX="${BRANCH_NAME%%-*}"  # alauda
+          BASE_VERSION="${BRANCH_NAME#${PREFIX}-}"  # v0.62.1
+
+          VERSION_NO_V="${BASE_VERSION#v}"              # 0.62.1
+          MAJOR=$(echo "$VERSION_NO_V" | cut -d. -f1)
+          MINOR=$(echo "$VERSION_NO_V" | cut -d. -f2)
+          PATCH=$(echo "$VERSION_NO_V" | cut -d. -f3)
+
+          echo "MAJOR: $MAJOR, MINOR: $MINOR, PATCH: $PATCH"
+
+          # PATCH + 1
+          NEXT_PATCH=$((PATCH + 1))
+          echo "NEXT_PATCH=$NEXT_PATCH"
+
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${NEXT_PATCH}"   # v0.62.2
+          echo "NEXT_VERSION=$NEXT_VERSION"
+
+          TAG_PREFIX="${NEXT_VERSION}-${PREFIX}"  # v0.62.2-alauda
+          echo "TAG_PREFIX=$TAG_PREFIX"
+
+          echo "prefix=$PREFIX" >> $GITHUB_OUTPUT
+          echo "base_version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_prefix=$TAG_PREFIX" >> $GITHUB_OUTPUT
+
+      - name: Find latest tag with this prefix
+        id: latest
+        run: |
+          TAG_PREFIX="${{ steps.extract.outputs.tag_prefix }}"
+          echo "Looking for tags with prefix: $TAG_PREFIX"
+
+          EXISTING_TAGS=$(git tag --list "${TAG_PREFIX}-*" | sort -V)
+          echo "Existing tags: $EXISTING_TAGS"
+
+          MAX_INDEX=-1
+          for tag in $EXISTING_TAGS; do
+            NUM=${tag##*-}
+            if [[ "$NUM" =~ ^[0-9]+$ && "$NUM" -gt "$MAX_INDEX" ]]; then
+              MAX_INDEX=$NUM
+            fi
+          done
+
+          NEW_INDEX=$((MAX_INDEX + 1))
+          NEW_TAG="${TAG_PREFIX}-${NEW_INDEX}"
+
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create and push new tag
+        run: |
+          NEW_TAG="${{ steps.latest.outputs.new_tag }}"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+  release-alauda:
+    name: Release Alauda
+    needs: [tag]
+    uses: ./.github/workflows/reusable-release-alauda.yaml

--- a/.github/workflows/alauda-auto-tag.yaml
+++ b/.github/workflows/alauda-auto-tag.yaml
@@ -12,6 +12,12 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      # Expose the freshly created tag so downstream jobs (release, sync)
+      # in the same workflow run can act on it without relying on the
+      # `push: tags:` event — that event is suppressed when the tag is
+      # pushed using the default GITHUB_TOKEN.
+      new_tag: ${{ steps.latest.outputs.new_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -85,3 +91,94 @@ jobs:
     name: Release Alauda
     needs: [tag]
     uses: ./.github/workflows/reusable-release-alauda.yaml
+
+  sync-to-nexus:
+    # Inlined from the former sync-to-nexus.yml workflow. We can't rely on
+    # `on.push.tags` to chain workflows here because the tag above is pushed
+    # with the default GITHUB_TOKEN, which by design does not trigger new
+    # workflow runs. Running sync as a downstream job in the same workflow
+    # run sidesteps that limitation entirely.
+    name: Sync Release To Nexus
+    needs: [tag]
+    runs-on: alauda-devops-runner
+    steps:
+      - name: create PipelineRun and follow logs
+        env:
+          TEKTON_NS: devops
+          # Pipeline source: catalog "alauda" via Tekton Hub resolver.
+          # Bump PIPELINE_VERSION together with catalog releases.
+          PIPELINE_CATALOG: alauda
+          PIPELINE_NAME: sync-github-release-to-nexus
+          PIPELINE_VERSION: "0.1"
+          # Component-aware PipelineRun name so the run is identifiable
+          # at a glance in `kubectl get pipelinerun` listings.
+          PR_NAME: sync-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          REPO: ${{ github.repository }}
+          # The tag was just produced by the `tag` job; pull it from the
+          # job output rather than github.ref_name (which here is the
+          # source branch, not a tag).
+          TAG: ${{ needs.tag.outputs.new_tag }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.tag.outputs.new_tag }}
+        run: |
+          set -euo pipefail
+
+          # Source-repo label uses dots instead of slashes to satisfy
+          # Kubernetes label value charset (no '/').
+          SOURCE_REPO_LABEL="${REPO//\//.}"
+
+          # Create PipelineRun with metadata.name (not generateName) so the
+          # PR name is known up front for `tkn pr logs -f` below.
+          # github-token workspace intentionally omitted: forks are public,
+          # pipeline declares it `optional: true` and falls back to anonymous.
+          cat <<EOF | kubectl create -f -
+          apiVersion: tekton.dev/v1
+          kind: PipelineRun
+          metadata:
+            name: ${PR_NAME}
+            namespace: ${TEKTON_NS}
+            labels:
+              alauda.io/source-repo: ${SOURCE_REPO_LABEL}
+              alauda.io/source-tag: ${TAG}
+              alauda.io/triggered-by: github-actions
+          spec:
+            pipelineRef:
+              resolver: hub
+              params:
+                - { name: catalog, value: ${PIPELINE_CATALOG} }
+                - { name: type,    value: tekton }
+                - { name: kind,    value: pipeline }
+                - { name: name,    value: ${PIPELINE_NAME} }
+                - { name: version, value: "${PIPELINE_VERSION}" }
+            params:
+              - { name: repo,        value: ${REPO} }
+              - { name: tag,         value: ${TAG} }
+              - { name: release-url, value: ${RELEASE_URL} }
+            workspaces:
+              - name: nexus-auth
+                secret:
+                  secretName: build-nexus.kauto
+              # Shared scratch PVC across the 5 run-script tasks. emptyDir
+              # would be per-pod and cannot propagate downloaded assets +
+              # intermediate metadata across TaskRuns; volumeClaimTemplate
+              # makes Tekton create a PipelineRun-owned PVC reaped with
+              # the run. RWO is sufficient — the DAG is strictly linear.
+              - name: source
+                volumeClaimTemplate:
+                  spec:
+                    storageClassName: topolvm
+                    accessModes:
+                      - ReadWriteOnce
+                    resources:
+                      requests:
+                        storage: 1Gi
+          EOF
+
+          # Stream logs until the PipelineRun completes; then surface the
+          # PipelineRun's Succeeded condition as the step exit code so the
+          # GitHub Actions UI reflects the real pipeline outcome.
+          tkn -n "${TEKTON_NS}" pr logs -f "${PR_NAME}"
+
+          STATUS=$(kubectl -n "${TEKTON_NS}" get pipelinerun "${PR_NAME}" \
+            -o jsonpath='{.status.conditions[?(@.type=="Succeeded")].status}')
+          echo "PipelineRun ${PR_NAME} final Succeeded status: ${STATUS}"
+          [ "${STATUS}" = "True" ]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '^1.20'
+        go-version-file: go.mod
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/release-alauda.yaml
+++ b/.github/workflows/release-alauda.yaml
@@ -1,0 +1,16 @@
+name: Release Alauda
+
+on:
+  push:
+    tags:
+      - "v*-alauda-*"
+  workflow_dispatch:
+
+permissions:
+  contents: write  # create releases
+  packages: write  # upload packages
+
+jobs:
+  release-alauda:
+    name: Release Alauda
+    uses: ./.github/workflows/reusable-release-alauda.yaml

--- a/.github/workflows/reusable-release-alauda.yaml
+++ b/.github/workflows/reusable-release-alauda.yaml
@@ -1,0 +1,33 @@
+name: Release Alauda
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: alauda-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.1.0
+          args: release -f=.goreleaser-alauda.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-alauda.yaml
+++ b/.github/workflows/scan-alauda.yaml
@@ -1,0 +1,34 @@
+name: Scan vulnerabilities for Alauda
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Scan Go vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: false
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.1.0
+          args: release --snapshot -f=.goreleaser-alauda.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'rootfs'
+          scan-ref: 'dist/cosign_linux_amd64_v1/alauda-cosign'
+          exit-code: 1

--- a/.github/workflows/scan-alauda.yaml
+++ b/.github/workflows/scan-alauda.yaml
@@ -30,5 +30,5 @@ jobs:
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'rootfs'
-          scan-ref: 'dist/cosign_linux_amd64_v1/alauda-cosign'
+          scan-ref: 'dist/yq_linux_amd64_v1/alauda-yq'
           exit-code: 1

--- a/.goreleaser-alauda.yml
+++ b/.goreleaser-alauda.yml
@@ -1,0 +1,58 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: yq
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -w -s -extldflags '-static'
+    main: .
+    binary: alauda-yq
+
+archives:
+  - id: archive
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    This release is intended for use only as part of the Alauda product suite.
+    It is not recommended for use by individuals or teams outside of Alauda.
+    Any consequences arising from its use are the sole responsibility of the user.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,64 @@
+# YQ alauda Branch Development Guide
+
+## Background
+
+Previously, yq was used as a general-purpose CLI across multiple plugins, each needing to fix vulnerabilities in yq independently.
+
+To avoid duplicated efforts, we forked the [yq](https://github.com/mikefarah/yq) repository and maintain it through branches named `alauda-vx.xx.xx`.
+
+We use [renovate](https://gitlab-ce.alauda.cn/devops/tech-research/renovate/-/blob/main/docs/quick-start/0002-quick-start.md) to automatically fix vulnerabilities in corresponding versions.
+
+## Repository Structure
+
+Based on the original code, the following content has been added:
+
+- [alauda-auto-tag.yaml](./.github/workflows/alauda-auto-tag.yaml): Automatically tags and triggers goreleaser when a PR is merged into the `alauda-vx.xx.xx` branch
+- [release-alauda.yaml](./.github/workflows/release-alauda.yaml): Supports triggering goreleaser manually or upon tag updates (this pipeline isn't triggered when tags are created by actions due to GitHub Actions design limitations)
+- [reusable-release-alauda.yaml](./.github/workflows/reusable-release-alauda.yaml): Executes goreleaser to create a release
+- [scan-alauda.yaml](.github/workflows/scan-alauda.yaml): Runs trivy vulnerability scans (`rootfs` scans for Go binaries)
+- [.goreleaser-alauda.yml](.goreleaser-alauda.yml): Configuration file for releasing alauda versions
+
+## Special Modifications
+
+None at present
+
+## Pipelines
+
+### Triggered on PR Submission
+
+- [tests.yaml](.github/workflows/tests.yaml): Official testing pipeline including unit tests, integration tests, etc.
+
+### Triggered on Merge to alauda-vx.xx.xx Branch
+
+- [alauda-auto-tag.yaml](.github/workflows/alauda-auto-tag.yaml): Automatically tags and triggers goreleaser
+- [reusable-release-alauda.yaml](.github/workflows/reusable-release-alauda.yaml): Executes goreleaser to create a release (triggered by `alauda-auto-tag.yaml`)
+
+### Scheduled or Manual Triggering
+
+- [scan-alauda.yaml](.github/workflows/scan-alauda.yaml): Runs trivy vulnerability scans (`rootfs` scans for Go binaries)
+
+### Others
+
+Other officially maintained pipelines remain unchanged; some irrelevant pipelines have been disabled on the Actions page.
+
+## Renovate Vulnerability Fix Mechanism
+
+The renovate configuration file is [renovate.json](https://github.com/AlaudaDevops/trivy/blob/main/renovate.json)
+
+1. renovate detects vulnerabilities in the branch and submits a PR for fixes
+2. Tests run automatically on the PR
+3. After all tests pass, renovate automatically merges the PR
+4. After the branch updates, an action automatically tags the commit (e.g., v0.62.1-alauda-0, with patch version and last digit incremented)
+5. goreleaser automatically publishes a release based on the tag
+
+## Maintenance Plan
+
+When upgrading to a new version, follow these steps:
+
+1. Create an alauda branch from the corresponding tag, e.g., tag `v0.62.1` corresponds to branch `alauda-v0.62.1`
+2. Cherry-pick previous alauda branch changes onto the new branch and push
+
+Renovate automatic fix mechanism:
+1. After renovate submits a PR, pipelines run automatically; if all tests pass, the PR will be merged automatically
+2. After merging into the `alauda-v0.62.1` branch, goreleaser will automatically create a `v0.62.2-alauda-0` release (note: not `v0.62.1-alauda-0`, because upgrading the version allows renovate to recognize it)
+3. renovate configured in other plugins will automatically fetch artifacts from the release according to its configuration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS builder
+FROM golang:1.25.6 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.6 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11 AS builder
+FROM golang:1.25.5 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.6 AS builder
+FROM golang:1.24.7 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1 AS builder
+FROM golang:1.26.2 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.9 AS builder
+FROM golang:1.24.10 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0 AS builder
+FROM golang:1.26.1 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7 AS builder
+FROM golang:1.26.0 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10 AS builder
+FROM golang:1.24.11 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.7 AS builder
+FROM golang:1.24.8 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 AS builder
+FROM golang:1.24.9 AS builder
 
 WORKDIR /go/src/mikefarah/yq
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.5
+FROM golang:1.25.6
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.6
+FROM golang:1.25.7
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.5
+FROM golang:1.24.6
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.1
+FROM golang:1.26.2
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.8
+FROM golang:1.24.9
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.7
+FROM golang:1.24.8
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.10
+FROM golang:1.24.11
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.0
+FROM golang:1.26.1
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.26.0
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.9
+FROM golang:1.24.10
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.2
+FROM golang:1.26.3
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.6
+FROM golang:1.24.7
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24.11
+FROM golang:1.25.5
 
 RUN apt-get update && \
     apt-get install -y npm && \

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -907,15 +908,8 @@ func (f *mockBoolFlag) Type() string {
 
 // Helper function to compare string slices
 func stringsEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	// Use the standard library comparator to avoid manual index handling.
+	return slices.Equal(a, b)
 }
 
 func TestSetupColors(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.24
-
-toolchain go1.24.1
+go 1.24.5

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.24.6
+go 1.25.0

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.7
+go 1.26.1

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.3
+go 1.25.4

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.26.2
+go 1.26.3

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.24.5
+go 1.24.6

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.26.1
+go 1.26.2

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.6
+go 1.25.7

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.1
+go 1.25.2

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.2
+go 1.25.3

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.5
+go 1.25.6

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.0
+go 1.25.1

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	golang.org/x/sys v0.34.0 // indirect
 )
 
-go 1.25.4
+go 1.25.5

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -ex
+
+# Keep tooling installation deterministic and aligned with the active Go toolchain.
+# This avoids prebuilt golangci-lint binaries being built by an older Go version.
+GOLANGCI_LINT_VERSION=v2.11.2
+GOSEC_VERSION=v2.22.5
+
 go mod download golang.org/x/tools@latest
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
-curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.22.5
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
+curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s ${GOSEC_VERSION}

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -ex
 go mod download golang.org/x/tools@latest
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.5
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
 curl -sSfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s v2.22.5


### PR DESCRIPTION
- Update the module Go version from 1.26.2 to 1.26.3.
- Keep the change limited to the root module metadata.
